### PR TITLE
Fix/improve German translation + add formal translation

### DIFF
--- a/DE-formal.json
+++ b/DE-formal.json
@@ -1,0 +1,13 @@
+{
+    "loadButtonLabel": "Klicken Sie hier, um das\nPanorama\nzu laden",
+    "loadingLabel": "Lade...",
+	"bylineLabel": "von %s",    
+
+    "noPanoramaError": "Es wurde kein Panorama angegeben.",
+    "fileAccessError": "Die Datei %s konnte nicht geöffnet werden.",
+    "malformedURLError": "Da stimmt etwas nicht mit der Panorama URL.",
+    "iOS8WebGLError": "Wegen der fehlerhaften WebGL Implementierung von iOS8 funktionieren nur progressiv enkodierte JPEGs auf Ihrem Gerät (dieses Panorama benutzt Standard Enkodierung).",
+    "genericWebGLError": "Ihr Browser hat nicht die nötige WebGL Unterstützung, um das Panorama anzeigen zu können.",
+	"textureSizeError": "Dieses Panorama ist zu groß für Ihr Gerät! Das Panorama ist %spx breit, ihr Gerät unterstützt allerdings nur eine maximal Größe von %spx. Versuchen Sie ein anderes Gerät. (Falls Sie der Autor sind, versuchen Sie, das Bild herunterzuskalieren.)", 
+    "unknownError": "Unbekannter Fehler. Schauen Sie in die Entwicklerkonsole."
+}

--- a/DE.json
+++ b/DE.json
@@ -1,13 +1,13 @@
 {
-    "loadButtonLabel": "Klicke hier um\nPanorama\nzu laden",
+    "loadButtonLabel": "Klicke hier, um\nPanorama\nzu laden",
     "loadingLabel": "Lade...",
 	"bylineLabel": "von %s",    
 
     "noPanoramaError": "Es wurde kein Panorama angegeben.",
     "fileAccessError": "Die Datei %s konnte nicht geöffnet werden.",
     "malformedURLError": "Da stimmt etwas nicht mit der Panorama URL.",
-    "iOS8WebGLError": "Wegen der fehlerhaften WebGL Implementierung von iOS8, funktionieren nur progressiv enkodierte JPEGs auf ihrem Gerät (dieses Panorama benutzt standard Enkodierung).",
-    "genericWebGLError": "Ihr Browser hat nicht die nötige WebGL Unterstützung um das Panorama anzeigen zu können.",
-	"textureSizeError": "Dieses Panorama ist zu groß für ihr Gerät! Das Panorama ist %spx breit, ihr Gerät unterstützt allerdings nur eine maximal Größe von %spx. Versuchen Sie ein anderes Gerät. (Falls Sie der Author sind, versuchen Sie das Bild herunterzuskalieren.)", 
-    "unknownError": "Unbekannter Fehler. Schauen Sie in die Entwicklerkonsole."
+    "iOS8WebGLError": "Wegen der fehlerhaften WebGL Implementierung von iOS8 funktionieren nur progressiv enkodierte JPEGs auf deinem Gerät (dieses Panorama benutzt Standard Enkodierung).",
+    "genericWebGLError": "Dein Browser hat nicht die nötige WebGL Unterstützung, um das Panorama anzeigen zu können.",
+	"textureSizeError": "Dieses Panorama ist zu groß für dein Gerät! Das Panorama ist %spx breit, dein Gerät unterstützt allerdings nur eine maximal Größe von %spx. Versuche ein anderes Gerät. (Falls du der Author bist, versuche, das Bild herunterzuskalieren.)", 
+    "unknownError": "Unbekannter Fehler. Schaue in die Entwicklerkonsole."
 }


### PR DESCRIPTION
The current German translation contains errors with mixed formal- and non-formal styles.
This PR fixes issues in the DE translation and makes it completely 
non-formal and also introduces a formal-style DE translation. 
(Similar to how WordPress handles translations).